### PR TITLE
Add and fix types for static WordArray.create()

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -3,9 +3,9 @@
 /**
  * Base class for inheritance.
  */
-import { Utf8 } from '../encoding/enc-utf8';
-import { Hex } from '../encoding/enc-hax';
-import { isString } from '../utils';
+import { Utf8, } from '../encoding/enc-utf8';
+import { Hex, } from '../encoding/enc-hax';
+import { isString, } from '../utils';
 
 let crypto;
 // Native crypto from window (Browser)
@@ -162,6 +162,17 @@ export class WordArray extends Base {
   }
 
   /**
+   * Creates and initializes a word array
+   * A compatibility method for crypto-js
+   *
+   * @param {Array} words (Optional) An array of 32-bit words.
+   * @param {number} sigBytes (Optional) The number of significant bytes in the words.
+   */
+  static create(words = [], sigBytes = words.length * 4) {
+    return new WordArray(words, sigBytes);
+  }
+
+  /**
    * Creates a word array filled with random bytes.
    *
    * @param {number} nBytes The number of random bytes to generate.
@@ -252,7 +263,7 @@ export class WordArray extends Base {
     // Shortcuts
     const {
       words,
-      sigBytes
+      sigBytes,
     } = this;
 
     // Clamp
@@ -351,7 +362,7 @@ export class BufferedBlockAlgorithm extends Base {
     // Shortcuts
     const {
       _data: data,
-      blockSize
+      blockSize,
     } = this;
     const dataWords = data.words;
     const dataSigBytes = data.sigBytes;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -894,7 +894,7 @@ declare global {
                  *     var wordArray = CryptoJSWasm.lib.WordArray.create([0x00010203, 0x04050607]);
                  *     var wordArray = CryptoJSWasm.lib.WordArray.create([0x00010203, 0x04050607], 6);
                  */
-                create(words?: number[], sigBytes?: number): WordArray;
+                create(words?: number[] | Uint8Array | Int8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array, sigBytes?: number): WordArray;
                 /**
                  * Creates a word array filled with random bytes.
                  *


### PR DESCRIPTION
Hello,
This pull request aims to fix a bug regarding the mismatch between `WordArray` in `index.d.ts` and the actual `WordArray` class. As the `WordArray` class does not have a `create` method, it cannot be instantiated using the `WordArray.create` method, as it's done in crypto-js, rendering this library incompatible with crypto-js. It also fixes the `create` method's arguments mismatch.