### PR TITLE
Fix the library for Webpack.

### DIFF
--- a/src/core/cipher-core.js
+++ b/src/core/cipher-core.js
@@ -3,17 +3,17 @@
 import {
   Base,
   WordArray,
-  BufferedBlockAlgorithm
+  BufferedBlockAlgorithm,
 } from '../core/core.js';
 import {
-  Base64
+  Base64,
 } from '../encoding/enc-base64.js';
 import {
-  EvpKDFAlgo
+  EvpKDFAlgo,
 } from '../encryption/evpkdf.js';
-import { isString } from '../utils';
-import { Pkcs7 } from '../pad/pad-pkcs7';
-import {MD5Algo} from '../algo/hash/md5';
+import { isString, } from '../utils';
+import { Pkcs7, } from '../pad/pad-pkcs7';
+import {MD5Algo,} from '../algo/hash/md5';
 
 
 /**
@@ -152,7 +152,7 @@ export class Cipher extends BufferedBlockAlgorithm {
 
       decrypt(ciphertext, key, cfg) {
         return selectCipherStrategy(key).decrypt(SubCipher, ciphertext, key, cfg);
-      }
+      },
     };
   }
 
@@ -324,7 +324,9 @@ function xorBlock(words, offset, blockSize) {
 /**
  * Abstract base CBC mode.
  */
-export class CBC extends BlockCipherMode { }
+export class CBC extends BlockCipherMode {
+  static _name = 'CBC';
+}
 /**
  * CBC encryptor.
  */
@@ -343,7 +345,7 @@ CBC.Encryptor = class extends CBC {
     // Shortcuts
     const cipher = this._cipher;
     const {
-      blockSize
+      blockSize,
     } = cipher;
 
     // XOR and encrypt
@@ -372,7 +374,7 @@ CBC.Decryptor = class extends CBC {
     // Shortcuts
     const cipher = this._cipher;
     const {
-      blockSize
+      blockSize,
     } = cipher;
 
     // Remember this block to use with next block
@@ -404,7 +406,7 @@ export class BlockCipher extends Cipher {
      */
     super(xformMode, key, Object.assign({
       mode: CBC,
-      padding: Pkcs7
+      padding: Pkcs7,
     },
     cfg,
     ));
@@ -420,11 +422,11 @@ export class BlockCipher extends Cipher {
 
     // Shortcuts
     const {
-      cfg
+      cfg,
     } = this;
     const {
       iv,
-      mode
+      mode,
     } = cfg;
 
     // Reset block mode
@@ -450,7 +452,7 @@ export class BlockCipher extends Cipher {
 
     // Shortcut
     const {
-      padding
+      padding,
     } = this.cfg;
 
     // Finalize
@@ -555,12 +557,12 @@ export const OpenSSLFormatter = {
     // Shortcuts
     const {
       ciphertext,
-      salt
+      salt,
     } = cipherParams;
 
     // Format
     if (salt) {
-      wordArray = new WordArray([0x53616c74, 0x65645f5f]).concat(salt).concat(ciphertext);
+      wordArray = new WordArray([0x53616c74, 0x65645f5f,]).concat(salt).concat(ciphertext);
     } else {
       wordArray = ciphertext;
     }
@@ -602,9 +604,9 @@ export const OpenSSLFormatter = {
 
     return new CipherParams({
       ciphertext,
-      salt
+      salt,
     });
-  }
+  },
 };
 
 /**
@@ -653,7 +655,7 @@ export class SerializableCipher extends Base {
       mode: cipherCfg.mode,
       padding: cipherCfg.padding,
       blockSize: encryptor.blockSize,
-      formatter: _cfg.format
+      formatter: _cfg.format,
     });
   }
 
@@ -726,7 +728,7 @@ export class SerializableCipher extends Base {
  */
 SerializableCipher.cfg = Object.assign(
   new Base(), {
-    format: OpenSSLFormatter
+    format: OpenSSLFormatter,
   },
 );
 
@@ -768,9 +770,9 @@ export const OpenSSLKdf = {
     // Derive key and IV
     let key;
     if (!hasher) {
-      key = new EvpKDFAlgo({keySize: keySize + ivSize}).compute(password, _salt);
+      key = new EvpKDFAlgo({keySize: keySize + ivSize,}).compute(password, _salt);
     } else {
-      key = new EvpKDFAlgo({keySize: keySize + ivSize, hasher: hasher}).compute(password, salt);
+      key = new EvpKDFAlgo({keySize: keySize + ivSize, hasher: hasher,}).compute(password, salt);
     }
 
     // Separate key and IV
@@ -781,9 +783,9 @@ export const OpenSSLKdf = {
     return new CipherParams({
       key,
       iv,
-      salt: _salt
+      salt: _salt,
     });
-  }
+  },
 };
 
 /**
@@ -891,5 +893,5 @@ export class PasswordBasedCipher extends SerializableCipher {
  *     Default: OpenSSL
  */
 PasswordBasedCipher.cfg = Object.assign(SerializableCipher.cfg, {
-  kdf: OpenSSLKdf
+  kdf: OpenSSLKdf,
 });

--- a/src/encryption/aes.js
+++ b/src/encryption/aes.js
@@ -1,8 +1,8 @@
-import {aesWasm} from './aes_bg';
-import {WordArray} from '../core/core';
-import {BlockCipher} from '../core/cipher-core.js';
-import {loadWasm} from '../utils/wasm-utils';
-import {wasmBytes} from './aes_wasm';
+import {aesWasm,} from './aes_bg';
+import {WordArray,} from '../core/core';
+import {BlockCipher,} from '../core/cipher-core.js';
+import {loadWasm,} from '../utils/wasm-utils';
+import {wasmBytes,} from './aes_wasm';
 
 /**
  * AES block cipher algorithm.
@@ -94,15 +94,15 @@ export class AESAlgo extends BlockCipher {
       // Perform concrete-algorithm logic
       if (this._xformMode == this._ENC_XFORM_MODE) {
         if (this.modeProcessBlock != undefined) {
-          this.modeProcessBlock = aesWasm(AESAlgo.wasm).doEncrypt(this.cfg.mode.name, this._nRounds, nWordsReady, blockSize, this.modeProcessBlock, dataArray, this._keySchedule);
+          this.modeProcessBlock = aesWasm(AESAlgo.wasm).doEncrypt(this.cfg.mode._name, this._nRounds, nWordsReady, blockSize, this.modeProcessBlock, dataArray, this._keySchedule);
         } else {
-          this.modeProcessBlock = aesWasm(AESAlgo.wasm).doEncrypt(this.cfg.mode.name, this._nRounds, nWordsReady, blockSize, ivWords, dataArray, this._keySchedule);
+          this.modeProcessBlock = aesWasm(AESAlgo.wasm).doEncrypt(this.cfg.mode._name, this._nRounds, nWordsReady, blockSize, ivWords, dataArray, this._keySchedule);
         }
       } else /* if (this._xformMode == this._DEC_XFORM_MODE) */ {
         if (this.modeProcessBlock != undefined) {
-          this.modeProcessBlock = aesWasm(AESAlgo.wasm).doDecrypt(this.cfg.mode.name, this._nRounds, nWordsReady, blockSize, this.modeProcessBlock, dataArray, this._keySchedule, this._invKeySchedule);
+          this.modeProcessBlock = aesWasm(AESAlgo.wasm).doDecrypt(this.cfg.mode._name, this._nRounds, nWordsReady, blockSize, this.modeProcessBlock, dataArray, this._keySchedule, this._invKeySchedule);
         } else {
-          this.modeProcessBlock = aesWasm(AESAlgo.wasm).doDecrypt(this.cfg.mode.name, this._nRounds, nWordsReady, blockSize, ivWords, dataArray, this._keySchedule, this._invKeySchedule);
+          this.modeProcessBlock = aesWasm(AESAlgo.wasm).doDecrypt(this.cfg.mode._name, this._nRounds, nWordsReady, blockSize, ivWords, dataArray, this._keySchedule, this._invKeySchedule);
         }
       }
       dataWords = Array.from(dataArray);

--- a/src/encryption/blowfish.js
+++ b/src/encryption/blowfish.js
@@ -1,8 +1,8 @@
-import {blowfishWasm} from './blowfish_bg';
-import {WordArray} from '../core/core';
-import {BlockCipher} from '../core/cipher-core.js';
-import {loadWasm} from '../utils/wasm-utils';
-import {wasmBytes} from './blowfish_wasm';
+import {blowfishWasm,} from './blowfish_bg';
+import {WordArray,} from '../core/core';
+import {BlockCipher,} from '../core/cipher-core.js';
+import {loadWasm,} from '../utils/wasm-utils';
+import {wasmBytes,} from './blowfish_wasm';
 
 /**
  * Blowfish block cipher algorithm.
@@ -109,15 +109,15 @@ export class BlowfishAlgo extends BlockCipher {
       // Perform concrete-algorithm logic
       if (this._xformMode == this._ENC_XFORM_MODE) {
         if (this.modeProcessBlock != undefined) {
-          this.modeProcessBlock = blowfishWasm(BlowfishAlgo.wasm).doEncrypt(this.cfg.mode.name, nWordsReady, blockSize, this.modeProcessBlock, dataArray, this.pbox, s);
+          this.modeProcessBlock = blowfishWasm(BlowfishAlgo.wasm).doEncrypt(this.cfg.mode._name, nWordsReady, blockSize, this.modeProcessBlock, dataArray, this.pbox, s);
         } else {
-          this.modeProcessBlock = blowfishWasm(BlowfishAlgo.wasm).doEncrypt(this.cfg.mode.name, nWordsReady, blockSize, ivWords, dataArray, this.pbox, s);
+          this.modeProcessBlock = blowfishWasm(BlowfishAlgo.wasm).doEncrypt(this.cfg.mode._name, nWordsReady, blockSize, ivWords, dataArray, this.pbox, s);
         }
       } else /* if (this._xformMode == this._DEC_XFORM_MODE) */ {
         if (this.modeProcessBlock != undefined) {
-          this.modeProcessBlock = blowfishWasm(BlowfishAlgo.wasm).doDecrypt(this.cfg.mode.name, nWordsReady, blockSize, this.modeProcessBlock, dataArray, this.pbox, s);
+          this.modeProcessBlock = blowfishWasm(BlowfishAlgo.wasm).doDecrypt(this.cfg.mode._name, nWordsReady, blockSize, this.modeProcessBlock, dataArray, this.pbox, s);
         } else {
-          this.modeProcessBlock = blowfishWasm(BlowfishAlgo.wasm).doDecrypt(this.cfg.mode.name, nWordsReady, blockSize, ivWords, dataArray, this.pbox, s);
+          this.modeProcessBlock = blowfishWasm(BlowfishAlgo.wasm).doDecrypt(this.cfg.mode._name, nWordsReady, blockSize, ivWords, dataArray, this.pbox, s);
         }
       }
       dataWords = Array.from(dataArray);

--- a/src/encryption/tripledes.js
+++ b/src/encryption/tripledes.js
@@ -1,8 +1,8 @@
-import {WordArray} from '../core/core.js';
-import {BlockCipher} from '../core/cipher-core.js';
-import {desWasm} from './des_bg';
-import {wasmBytes} from './des_wasm';
-import {loadWasm} from '../utils/wasm-utils';
+import {WordArray,} from '../core/core.js';
+import {BlockCipher,} from '../core/cipher-core.js';
+import {desWasm,} from './des_bg';
+import {wasmBytes,} from './des_wasm';
+import {loadWasm,} from '../utils/wasm-utils';
 
 // Permuted Choice 1 constants
 const PC1 = [
@@ -12,7 +12,7 @@ const PC1 = [
   60, 52, 44, 36, 63, 55, 47, 39,
   31, 23, 15, 7, 62, 54, 46, 38,
   30, 22, 14, 6, 61, 53, 45, 37,
-  29, 21, 13, 5, 28, 20, 12, 4
+  29, 21, 13, 5, 28, 20, 12, 4,
 ];
 
 // Permuted Choice 2 constants
@@ -24,11 +24,11 @@ const PC2 = [
   41, 52, 31, 37, 47, 55,
   30, 40, 51, 45, 33, 48,
   44, 49, 39, 56, 34, 53,
-  46, 42, 50, 36, 29, 32
+  46, 42, 50, 36, 29, 32,
 ];
 
 // Cumulative bit shift constants
-const BIT_SHIFTS = [1, 2, 4, 6, 8, 10, 12, 14, 15, 17, 19, 21, 23, 25, 27, 28];
+const BIT_SHIFTS = [1, 2, 4, 6, 8, 10, 12, 14, 15, 17, 19, 21, 23, 25, 27, 28,];
 
 /**
  * DES block cipher algorithm.
@@ -163,15 +163,15 @@ export class DESAlgo extends BlockCipher {
       // Perform concrete-algorithm logic
       if (this._xformMode == this._ENC_XFORM_MODE) {
         if (this.modeProcessBlock != undefined) {
-          this.modeProcessBlock = desWasm(DESAlgo.wasm).doEncrypt(this.cfg.mode.name, nWordsReady, blockSize, this.modeProcessBlock, dataArray, this._key.words);
+          this.modeProcessBlock = desWasm(DESAlgo.wasm).doEncrypt(this.cfg.mode._name, nWordsReady, blockSize, this.modeProcessBlock, dataArray, this._key.words);
         } else {
-          this.modeProcessBlock = desWasm(DESAlgo.wasm).doEncrypt(this.cfg.mode.name, nWordsReady, blockSize, ivWords, dataArray, this._key.words);
+          this.modeProcessBlock = desWasm(DESAlgo.wasm).doEncrypt(this.cfg.mode._name, nWordsReady, blockSize, ivWords, dataArray, this._key.words);
         }
       } else /* if (this._xformMode == this._DEC_XFORM_MODE) */ {
         if (this.modeProcessBlock != undefined) {
-          this.modeProcessBlock = desWasm(DESAlgo.wasm).doDecrypt(this.cfg.mode.name, nWordsReady, blockSize, this.modeProcessBlock, dataArray, this._key.words);
+          this.modeProcessBlock = desWasm(DESAlgo.wasm).doDecrypt(this.cfg.mode._name, nWordsReady, blockSize, this.modeProcessBlock, dataArray, this._key.words);
         } else {
-          this.modeProcessBlock = desWasm(DESAlgo.wasm).doDecrypt(this.cfg.mode.name, nWordsReady, blockSize, ivWords, dataArray, this._key.words);
+          this.modeProcessBlock = desWasm(DESAlgo.wasm).doDecrypt(this.cfg.mode._name, nWordsReady, blockSize, ivWords, dataArray, this._key.words);
         }
       }
       dataWords = Array.from(dataArray);
@@ -284,15 +284,15 @@ export class TripleDESAlgo extends BlockCipher {
       // Perform concrete-algorithm logic
       if (this._xformMode == this._ENC_XFORM_MODE) {
         if (this.modeProcessBlock != undefined) {
-          this.modeProcessBlock = desWasm(DESAlgo.wasm).tripleEncrypt(this.cfg.mode.name, nWordsReady, blockSize, this.modeProcessBlock, dataArray, key1, key2, key3);
+          this.modeProcessBlock = desWasm(DESAlgo.wasm).tripleEncrypt(this.cfg.mode._name, nWordsReady, blockSize, this.modeProcessBlock, dataArray, key1, key2, key3);
         } else {
-          this.modeProcessBlock = desWasm(DESAlgo.wasm).tripleEncrypt(this.cfg.mode.name, nWordsReady, blockSize, ivWords, dataArray, key1, key2, key3);
+          this.modeProcessBlock = desWasm(DESAlgo.wasm).tripleEncrypt(this.cfg.mode._name, nWordsReady, blockSize, ivWords, dataArray, key1, key2, key3);
         }
       } else /* if (this._xformMode == this._DEC_XFORM_MODE) */ {
         if (this.modeProcessBlock != undefined) {
-          this.modeProcessBlock = desWasm(DESAlgo.wasm).tripleDecrypt(this.cfg.mode.name, nWordsReady, blockSize, this.modeProcessBlock, dataArray, key1, key2, key3);
+          this.modeProcessBlock = desWasm(DESAlgo.wasm).tripleDecrypt(this.cfg.mode._name, nWordsReady, blockSize, this.modeProcessBlock, dataArray, key1, key2, key3);
         } else {
-          this.modeProcessBlock = desWasm(DESAlgo.wasm).tripleDecrypt(this.cfg.mode.name, nWordsReady, blockSize, ivWords, dataArray, key1, key2, key3);
+          this.modeProcessBlock = desWasm(DESAlgo.wasm).tripleDecrypt(this.cfg.mode._name, nWordsReady, blockSize, ivWords, dataArray, key1, key2, key3);
         }
       }
       dataWords = Array.from(dataArray);

--- a/src/mode/mode-cfb.js
+++ b/src/mode/mode-cfb.js
@@ -1,5 +1,5 @@
 import {
-  BlockCipherMode
+  BlockCipherMode,
 } from '../core/cipher-core.js';
 
 function generateKeystreamAndEncrypt(words, offset, blockSize, cipher) {
@@ -30,7 +30,7 @@ function generateKeystreamAndEncrypt(words, offset, blockSize, cipher) {
  * Cipher Feedback block mode.
  */
 export class CFB extends BlockCipherMode {
-
+  static _name = 'CFB';
   static Encryptor(){}
 
 }
@@ -38,7 +38,7 @@ CFB.Encryptor = class extends CFB {
   processBlock(words, offset) {
     // Shortcuts
     const cipher = this._cipher;
-    const { blockSize } = cipher;
+    const { blockSize, } = cipher;
 
     generateKeystreamAndEncrypt.call(this, words, offset, blockSize, cipher);
 
@@ -50,7 +50,7 @@ CFB.Decryptor = class extends CFB {
   processBlock(words, offset) {
     // Shortcuts
     const cipher = this._cipher;
-    const { blockSize } = cipher;
+    const { blockSize, } = cipher;
 
     // Remember this block to use with next block
     const thisBlock = words.slice(offset, offset + blockSize);

--- a/src/mode/mode-ctr-gladman.js
+++ b/src/mode/mode-ctr-gladman.js
@@ -1,5 +1,5 @@
 import {
-  BlockCipherMode
+  BlockCipherMode,
 } from '../core/cipher-core.js';
 
 const incWord = (word) => {
@@ -53,6 +53,7 @@ const incCounter = (counter) => {
  * Jan Hruby jhruby.web@gmail.com
  */
 export class CTRGladman extends BlockCipherMode {
+  static _name = 'CTRGladman';
 }
 CTRGladman.Encryptor = class extends CTRGladman {
   processBlock(words, offset) {
@@ -60,7 +61,7 @@ CTRGladman.Encryptor = class extends CTRGladman {
 
     // Shortcuts
     const cipher = this._cipher;
-    const { blockSize } = cipher;
+    const { blockSize, } = cipher;
     const iv = this._iv;
     let counter = this._counter;
 

--- a/src/mode/mode-ctr.js
+++ b/src/mode/mode-ctr.js
@@ -2,10 +2,11 @@
  * Counter block mode.
  */
 import {
-  BlockCipherMode
+  BlockCipherMode,
 } from '../core/cipher-core.js';
 
 export class CTR extends BlockCipherMode {
+  static _name = 'CTR';
 }
 CTR.Encryptor = class extends CTR {
   processBlock(words, offset) {
@@ -13,7 +14,7 @@ CTR.Encryptor = class extends CTR {
 
     // Shortcuts
     const cipher = this._cipher;
-    const { blockSize } = cipher;
+    const { blockSize, } = cipher;
     const iv = this._iv;
     let counter = this._counter;
 

--- a/src/mode/mode-ecb.js
+++ b/src/mode/mode-ecb.js
@@ -2,10 +2,11 @@
  * Electronic Codebook block mode.
  */
 import {
-  BlockCipherMode
+  BlockCipherMode,
 } from '../core/cipher-core.js';
 
 export class ECB extends BlockCipherMode {
+  static _name = 'ECB';
 }
 ECB.Encryptor = class extends ECB {
   processBlock(words, offset) {

--- a/src/mode/mode-ofb.js
+++ b/src/mode/mode-ofb.js
@@ -2,10 +2,11 @@
  * Output Feedback block mode.
  */
 import {
-  BlockCipherMode
+  BlockCipherMode,
 } from '../core/cipher-core.js';
 
 export class OFB extends BlockCipherMode {
+  static _name = 'OFB';
 }
 OFB.Encryptor = class extends OFB {
   processBlock(words, offset) {
@@ -13,7 +14,7 @@ OFB.Encryptor = class extends OFB {
 
     // Shortcuts
     const cipher = this._cipher;
-    const { blockSize } = cipher;
+    const { blockSize, } = cipher;
     const iv = this._iv;
     let keystream = this._keystream;
 


### PR DESCRIPTION
Hello
It seems that this library uses the `class.name` property for block cipher modes.
This breaks once the library gets processed by Webpack.
This pull request aims to fix that by instead defining a `static _name = '<class name>'` property, and using that instead of `class.name`.